### PR TITLE
Retarget extension documentation URL

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -4,7 +4,7 @@
 	"author": [
 		"Alexey"
 	],
-	"url": "https://www.mediawiki.org/wiki/Extension:UploadWizardExtraButtons",
+	"url": "https://github.com/vedmaka/mediawiki-extension-UploadWizardExtraButtons#readme",
 	"descriptionmsg": "uploadwizardextrabuttons-desc",
 	"license-name": "MIT",
 	"type": "other",


### PR DESCRIPTION
Instead of pointing to a missing page on MediaWiki.org, use the repository's documentation.